### PR TITLE
Added `"moduleResolution": "node"` compiler option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "importsNotUsedAsValues": "error",
 
     /* Module Resolution Options */
+    "moduleResolution": "node",
     "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
     "paths": {
       "$utils/*": ["src/utils/*"]


### PR DESCRIPTION
This is required to import npm packages with Typescript, I always need to set this option manually every time I start a new project.