### PR TITLE
Ignore `dist` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Production files
+dist

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,2 +1,0 @@
-(()=>{var o=n=>{console.log(`Hello ${n}!`);console.log('Is this a short code snippet? Try compiling this file with Typescript by running the "tsc" command on your terminal.'),console.log('Is this a big project? Try bundling and minifying the files with ESBuild by adding them in the "build.js" config file and running the "npm run build" command on your terminal.')};document.addEventListener("DOMContentLoaded",()=>{o("John Doe")});})();
-/*! This comment will be untouched when compiling */


### PR DESCRIPTION
Now that we're automatically deploying to NPM, it doesn't make sense to commit the `dist` folder in the repo. It just increments the diffing without any real value nor benefit.