### PR TITLE
Add(chore): jquery on dev mode only

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -18,6 +18,7 @@ const defaultSettings = {
   sourcemap: !production,
   target: production ? 'es2017' : 'esnext',
   entryPoints,
+  external: ['jquery'],
 };
 
 // Files building

--- a/bin/build.js
+++ b/bin/build.js
@@ -18,7 +18,6 @@ const defaultSettings = {
   sourcemap: !production,
   target: production ? 'es2017' : 'esnext',
   entryPoints,
-  external: ['jquery'],
 };
 
 // Files building

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@finsweet/tsconfig": "^1.1.0",
     "@playwright/test": "^1.25.0",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
+    "@types/jquery": "^3.5.14",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "cross-env": "^7.0.3",
@@ -51,6 +52,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@finsweet/ts-utils": "^0.33.1"
+    "@finsweet/ts-utils": "^0.33.1",
+    "jquery": "^3.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@finsweet/ts-utils": "^0.33.1",
-    "jquery": "^3.6.1"
+    "@finsweet/ts-utils": "^0.33.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,11 @@ specifiers:
   eslint: ^8.21.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.2.1
-  jquery: ^3.6.1
   prettier: ^2.7.1
   typescript: ^4.7.4
 
 dependencies:
   '@finsweet/ts-utils': 0.33.1
-  jquery: 3.6.1
 
 devDependencies:
   '@changesets/changelog-git': 0.1.12
@@ -2059,10 +2057,6 @@ packages:
   /javascript-natural-sort/0.7.1:
     resolution: {integrity: sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=}
     dev: true
-
-  /jquery/3.6.1:
-    resolution: {integrity: sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==}
-    dev: false
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   '@finsweet/tsconfig': ^1.1.0
   '@playwright/test': ^1.25.0
   '@trivago/prettier-plugin-sort-imports': ^3.3.0
+  '@types/jquery': ^3.5.14
   '@typescript-eslint/eslint-plugin': ^5.33.0
   '@typescript-eslint/parser': ^5.33.0
   cross-env: ^7.0.3
@@ -15,11 +16,13 @@ specifiers:
   eslint: ^8.21.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.2.1
+  jquery: ^3.6.1
   prettier: ^2.7.1
   typescript: ^4.7.4
 
 dependencies:
   '@finsweet/ts-utils': 0.33.1
+  jquery: 3.6.1
 
 devDependencies:
   '@changesets/changelog-git': 0.1.12
@@ -28,6 +31,7 @@ devDependencies:
   '@finsweet/tsconfig': 1.1.0
   '@playwright/test': 1.25.0
   '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.7.1
+  '@types/jquery': 3.5.14
   '@typescript-eslint/eslint-plugin': 5.33.0_njno5y7ry2l2lcmiu4tywxkwnq
   '@typescript-eslint/parser': 5.33.0_qugx7qdu5zevzvxaiqyxfiwquq
   cross-env: 7.0.3
@@ -658,6 +662,12 @@ packages:
       ci-info: 3.3.2
     dev: true
 
+  /@types/jquery/3.5.14:
+    resolution: {integrity: sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==}
+    dependencies:
+      '@types/sizzle': 2.3.3
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -680,6 +690,10 @@ packages:
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
+    dev: true
+
+  /@types/sizzle/2.3.3:
+    resolution: {integrity: sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==}
     dev: true
 
   /@typescript-eslint/eslint-plugin/5.33.0_njno5y7ry2l2lcmiu4tywxkwnq:
@@ -2045,6 +2059,10 @@ packages:
   /javascript-natural-sort/0.7.1:
     resolution: {integrity: sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=}
     dev: true
+
+  /jquery/3.6.1:
+    resolution: {integrity: sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==}
+    dev: false
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}


### PR DESCRIPTION
Hey 👋

This PR is about including jQuery with the types to the dev env but remove this external librairie at the build time.

## Why?
This template will be used mostly by Webflow developers, and some of them are using jQuery. But a lot of Webflow developers has not the experience of real typescript developers, so including it by default and remove it from the build out of the box may be a good idea. I had the case with a friend learning typescript with Webflow today. I talked about ESBuild to him, the @types packages and it was a lot to understand.

## How?
By installing jquery and @types/jquery to the project.

## How to test?
Use jquery to do a simple task, it should works as excepted. Build the code, jquery should not be part of the bundle.
