### PR TITLE
`feat`: define `@finsweet/ts-utils` types for better support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "./",
     "paths": {
       "$utils/*": ["src/utils/*"]
-    }
+    },
+    "types": ["@finsweet/ts-utils"]
   }
 }


### PR DESCRIPTION
Some type definitions exported by `@finsweet/ts-utils` are currently only being processed by the language server when the project has at least one module imported from `@finsweet/ts-utils`.

An example is `window.Webflow`. So this would work:
```typescript
import { getPublishDate } from '@finsweet/ts-utils';

window.Webflow ||= [];
window.Webflow.push(() => {
  console.log(getPublishDate());
});
```
Because `getPublishDate` is being imported from `@finsweet/ts-utils`.

But this would throw a type error (assuming this is the only file in the project), because `@finsweet/ts-utils` is not being imported anywhere:
```typescript
window.Webflow ||= []; // Error: Property 'Webflow' does not exist on type 'Window & typeof globalThis'.
window.Webflow.push(() => {
  console.log('Hey!');
});
```

By adding `@finsweet/ts-utils` to the `compilerOptions.types` field we ensure these type definitions are always present, even when the package is not being imported anywhere in the project (it has to be at least installed, obiously).