### PR TITLE
Improve build to include all types of outputs & explain CSS bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ const entryPoints = [
 
 This will tell `esbuild` to build all those files and output them in the `dist` folder for production and in `http://localhost:3000` for development.
 
+### Building CSS files
+
+CSS files are also supported by the bundler. When including a CSS file as an entry point, the compiler will generate a minified version in your output folder.
+
+You can define a CSS entry point by either:
+
+- Manually defining it in the `bin/build.js` config. [See previous section](#building-multiple-files) for reference.
+- Or importing the file inside any of your JavaScript / TypeScript files:
+
+```typescript
+// src/index.ts
+import './index.css';
+```
+
+CSS outputs are also available in `localhost` during [development mode](#serving-files-on-development-mode).
+
 ### Setting up a path alias
 
 Path aliases are very helpful to avoid code like:

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 import * as esbuild from 'esbuild';
+import { readdirSync } from 'fs';
+import { join } from 'path';
 
 // Config output
 const BUILD_DIRECTORY = 'dist';
@@ -41,19 +43,27 @@ else {
       port: SERVE_PORT,
     })
     .then(async ({ port }) => {
+      const buildDirectory = join(process.cwd(), BUILD_DIRECTORY);
+      const files = readdirSync(buildDirectory);
+
       // Log all served files for easy reference
       console.table(
-        ENTRY_POINTS.map((path) => {
-          const file = path.replace('src/', '').replace('.ts', '.js');
-          const location = `http://localhost:${port}/${file}`;
-          const script = `<script defer src="${location}"></script>`;
+        files
+          .map((file) => {
+            if (file.endsWith('map')) return;
 
-          return {
-            'Built File': file,
-            'File Location': location,
-            'Script Suggestion': script,
-          };
-        })
+            const location = `http://localhost:${port}/${file}`;
+            const tag = file.endsWith('css')
+              ? `<link href="${location}" rel="stylesheet" type="text/css"/>`
+              : `<script defer src="${location}"></script>`;
+
+            return {
+              'Built File': file,
+              'File Location': location,
+              'Import Suggestion': tag,
+            };
+          })
+          .filter(Boolean)
       );
     });
 }


### PR DESCRIPTION
Closes #30 

- Improves the `build.js` script to include all kind of outputs when serving in local:
![image](https://user-images.githubusercontent.com/61051948/223402896-90b12ff6-67f5-4a39-b757-8e811d68caec.png)

- Docs: explain about building CSS files.