### PR TITLE
refactor: define explicit `SERVE_ORIGIN` in `build.js`

### DIFF
--- a/bin/live-reload.js
+++ b/bin/live-reload.js
@@ -1,3 +1,1 @@
-new EventSource(`http://localhost:${SERVE_PORT}/esbuild`).addEventListener('change', () =>
-  location.reload()
-);
+new EventSource(`${SERVE_ORIGIN}/esbuild`).addEventListener('change', () => location.reload());


### PR DESCRIPTION
Simple tweak in our `build.js` script that explicitly defines the serve origin.
This makes it easier to replace it when using the `developer-starter` template in remove environments like GitHub Codespaces, Stackblitz or GitPod.